### PR TITLE
Consolidate all errors, use onErrorHtml

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -35,11 +35,13 @@ library:
     - http-types >=0.8 && <0.13
     - memory
     - microlens
+    - mtl
     - safe-exceptions
     - text >=0.7 && <2.0
     - uri-bytestring
     - yesod-auth >=1.6.0 && <1.7
     - yesod-core >=1.6.0 && <1.7
+    - unliftio
 
 executables:
   yesod-auth-oauth2-example:

--- a/src/UnliftIO/Except.hs
+++ b/src/UnliftIO/Except.hs
@@ -1,0 +1,12 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module UnliftIO.Except
+    () where
+
+import Control.Monad.Except
+import UnliftIO
+
+instance (MonadUnliftIO m, Exception e) => MonadUnliftIO (ExceptT e m) where
+    withRunInIO exceptToIO = ExceptT $ try $ do
+        withRunInIO $ \runInIO ->
+            exceptToIO (runInIO . (either throwIO pure <=< runExceptT))

--- a/src/Yesod/Auth/OAuth2/Dispatch.hs
+++ b/src/Yesod/Auth/OAuth2/Dispatch.hs
@@ -81,8 +81,8 @@ dispatchCallback
     -> FetchCreds site
     -> m TypedContent
 dispatchCallback name oauth2 getToken getCreds = do
-    csrf <- verifySessionCSRF $ tokenSessionKey name
     onErrorResponse $ throwError . OAuth2HandshakeError
+    csrf <- verifySessionCSRF $ tokenSessionKey name
     code <- requireGetParam "code"
     manager <- authHttpManager
     oauth2' <- withCallbackAndState name oauth2 csrf

--- a/src/Yesod/Auth/OAuth2/Dispatch.hs
+++ b/src/Yesod/Auth/OAuth2/Dispatch.hs
@@ -101,13 +101,8 @@ withCallbackAndState
     -> Text
     -> m OAuth2
 withCallbackAndState name oauth2 csrf = do
-    let url = PluginR name ["callback"]
-    render <- getParentUrlRender
-    let callbackText = render url
-
-    callback <- maybe (throwError $ InvalidCallbackUri callbackText) pure
-        $ fromText callbackText
-
+    uri <- ($ PluginR name ["callback"]) <$> getParentUrlRender
+    callback <- maybe (throwError $ InvalidCallbackUri uri) pure $ fromText uri
     pure oauth2
         { oauthCallback = Just callback
         , oauthOAuthorizeEndpoint =

--- a/src/Yesod/Auth/OAuth2/Dispatch.hs
+++ b/src/Yesod/Auth/OAuth2/Dispatch.hs
@@ -19,8 +19,8 @@ import Data.Text.Encoding (encodeUtf8)
 import Network.HTTP.Conduit (Manager)
 import Network.OAuth.OAuth2
 import Network.OAuth.OAuth2.TokenRequest (Errors)
-import UnliftIO.Exception
 import URI.ByteString.Extension
+import UnliftIO.Exception
 import Yesod.Auth hiding (ServerError)
 import Yesod.Auth.OAuth2.DispatchError
 import Yesod.Auth.OAuth2.ErrorResponse

--- a/src/Yesod/Auth/OAuth2/Dispatch.hs
+++ b/src/Yesod/Auth/OAuth2/Dispatch.hs
@@ -140,12 +140,9 @@ verifySessionCSRF sessionKey = do
     token <- requireGetParam "state"
     sessionToken <- lookupSession sessionKey
     deleteSession sessionKey
-
-    unless (sessionToken == Just token) $ throwError $ InvalidStateToken
-        sessionToken
-        token
-
-    pure token
+    token <$ unless
+        (sessionToken == Just token)
+        (throwError $ InvalidStateToken sessionToken token)
 
 requireGetParam
     :: (MonadError DispatchError m, MonadHandler m) => Text -> m Text

--- a/src/Yesod/Auth/OAuth2/Dispatch.hs
+++ b/src/Yesod/Auth/OAuth2/Dispatch.hs
@@ -149,10 +149,8 @@ verifySessionCSRF sessionKey = do
 
 requireGetParam
     :: (MonadError DispatchError m, MonadHandler m) => Text -> m Text
-requireGetParam key = do
-    m <- lookupGetParam key
-    maybe err return m
-    where err = throwError $ MissingParameter key
+requireGetParam key =
+    maybe (throwError $ MissingParameter key) pure =<< lookupGetParam key
 
 tokenSessionKey :: Text -> Text
 tokenSessionKey name = "_yesod_oauth2_" <> name

--- a/src/Yesod/Auth/OAuth2/DispatchError.hs
+++ b/src/Yesod/Auth/OAuth2/DispatchError.hs
@@ -1,0 +1,78 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Yesod.Auth.OAuth2.DispatchError
+    ( DispatchError(..)
+    , handleDispatchError
+    ) where
+
+import Control.Monad.Except
+import Data.Text (Text, pack)
+import Network.OAuth.OAuth2
+import Network.OAuth.OAuth2.TokenRequest (Errors)
+import UnliftIO.Except ()
+import UnliftIO.Exception
+import Yesod.Auth hiding (ServerError)
+import Yesod.Auth.OAuth2.ErrorResponse
+import Yesod.Auth.OAuth2.Exception
+import Yesod.Auth.OAuth2.Random
+import Yesod.Core hiding (ErrorResponse)
+
+data DispatchError
+    = MissingParameter Text
+    | InvalidStateToken (Maybe Text) Text
+    | InvalidCallbackUri Text
+    | OAuth2HandshakeError ErrorResponse
+    | OAuth2ResultError (OAuth2Error Errors)
+    | FetchCredsIOException IOException
+    | FetchCredsYesodOAuth2Exception YesodOAuth2Exception
+    deriving stock Show
+    deriving anyclass Exception
+
+-- | User-friendly message for any given 'DispatchError'
+--
+-- Most of these are opaque to the user. The exception details are present for
+-- the server logs.
+--
+dispatchErrorMessage :: DispatchError -> Text
+dispatchErrorMessage = \case
+    MissingParameter name ->
+        "Parameter '" <> name <> "' is required, but not present in the URL"
+    InvalidStateToken{} -> "State token is invalid, please try again"
+    InvalidCallbackUri{}
+        -> "Callback URI was not valid, this server may be misconfigured (no approot)"
+    OAuth2HandshakeError er -> "OAuth2 handshake failure: " <> erUserMessage er
+    OAuth2ResultError{} -> "Login failed, please try again"
+    FetchCredsIOException{} -> "Login failed, please try again"
+    FetchCredsYesodOAuth2Exception{} -> "Login failed, please try again"
+
+handleDispatchError
+    :: MonadAuthHandler site m
+    => ExceptT DispatchError m TypedContent
+    -> m TypedContent
+handleDispatchError f = do
+    result <- runExceptT f
+    either onDispatchError pure result
+
+onDispatchError :: MonadAuthHandler site m => DispatchError -> m TypedContent
+onDispatchError err = do
+    errorId <- liftIO $ randomText 16
+    let suffix = " [errorId=" <> errorId <> "]"
+    $(logError) $ pack (displayException err) <> suffix
+
+    let message = dispatchErrorMessage err <> suffix
+        messageValue =
+            object ["error" .= object ["id" .= errorId, "message" .= message]]
+
+    loginR <- ($ LoginR) <$> getRouteToParent
+
+    selectRep $ do
+        provideRep @_ @Html $ onErrorHtml loginR message
+        provideRep @_ @Value $ pure messageValue

--- a/src/Yesod/Auth/OAuth2/Random.hs
+++ b/src/Yesod/Auth/OAuth2/Random.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE TypeApplications #-}
+
+module Yesod.Auth.OAuth2.Random
+    ( randomText
+    ) where
+
+import Crypto.Random (MonadRandom, getRandomBytes)
+import Data.ByteArray.Encoding (Base(Base64), convertToBase)
+import Data.ByteString (ByteString)
+import Data.Text (Text)
+import Data.Text.Encoding (decodeUtf8)
+
+randomText
+    :: MonadRandom m
+    => Int
+    -- ^ Size in Bytes (note necessarily characters)
+    -> m Text
+randomText size =
+    decodeUtf8 . convertToBase @ByteString Base64 <$> getRandomBytes size


### PR DESCRIPTION
Prior to this commit, some errors would be thrown (missing parameter, invalid
state, incorrect approot) while others would be handled via the
set-message-redirect approach (handshake failure, fetch-token failure, etc).

This commit consolidates all of these cases into a single `DispatchError` type,
and then uses `MonadError` (concretely `ExceptT`) to capture them all and handle
them in one place ourselves.

It then updates that handling to:

- Use `onErrorHtml`

  `onErrorHtml` will, by default, set-message-redirect. That make this behavior
  neutral for users running defaults. For users that have customized this, it
  will be an improvement that all our error cases now respect it.

- Provided a JSON representation of errors
- Attach a random correlation identifier

The last two were just nice-to-haves that were cheap to add once the code was in
this state.

Note that the use of `MonadError` requires a potentially "bad" orphan
`MonadUnliftIO` instance for `ExceptT`, but I'd like to see that instance become
a reality and think it needs some real-world experimentation to get there, so
here I am.