### PR TITLE
Expose `onDispatchError` and generic error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## [_Unreleased_](https://github.com/thoughtbot/yesod-auth-oauth2/compare/v0.6.2.3...main)
+## [_Unreleased_](https://github.com/thoughtbot/yesod-auth-oauth2/compare/v0.6.3.0...main)
+
+None
+
+## [v0.6.3.0](https://github.com/thoughtbot/yesod-auth-oauth2/compare/v0.6.2.3...v0.6.3.0)
 
 - Expose `onDispatchError` and generic `OtherDispatchError` for passthrough log
 - Don't throw exceptions; handle all errors through the set-message-redirect path

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [_Unreleased_](https://github.com/thoughtbot/yesod-auth-oauth2/compare/v0.6.2.3...main)
 
+- Expose `onDispatchError` and generic `OtherDispatchError` for passthrough log
 - Don't throw exceptions; handle all errors through the set-message-redirect path
 - Respect `onErrorHtml` for said error-handling
 - Support custom widget in Google plugin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ None
 ## [v0.6.3.0](https://github.com/thoughtbot/yesod-auth-oauth2/compare/v0.6.2.3...v0.6.3.0)
 
 - Expose `onDispatchError` and generic `OtherDispatchError` for passthrough log
-- Don't throw exceptions; handle all errors through the set-message-redirect path
+- Don't throw exceptions; handle all errors through the set-message-redirect
+  path
 - Respect `onErrorHtml` for said error-handling
 - Support custom widget in Google plugin
   [@jmorag](https://github.com/freckle/yesod-auth-oauth2/pull/149)

--- a/package.yaml
+++ b/package.yaml
@@ -1,6 +1,6 @@
 ---
 name: yesod-auth-oauth2
-version: "0.6.2.3" # N.B. PVP-compliant Semver: 0.MAJOR.MINOR.PATCH
+version: "0.6.3.0" # N.B. PVP-compliant Semver: 0.MAJOR.MINOR.PATCH
 synopsis: OAuth 2.0 authentication plugins
 description: Library to authenticate with OAuth 2.0 for Yesod web applications.
 category: Web

--- a/src/Yesod/Auth/OAuth2/DispatchError.hs
+++ b/src/Yesod/Auth/OAuth2/DispatchError.hs
@@ -11,6 +11,7 @@
 module Yesod.Auth.OAuth2.DispatchError
     ( DispatchError(..)
     , handleDispatchError
+    , onDispatchError
     ) where
 
 import Control.Monad.Except
@@ -33,6 +34,7 @@ data DispatchError
     | OAuth2ResultError (OAuth2Error Errors)
     | FetchCredsIOException IOException
     | FetchCredsYesodOAuth2Exception YesodOAuth2Exception
+    | OtherDispatchError Text
     deriving stock Show
     deriving anyclass Exception
 
@@ -52,6 +54,7 @@ dispatchErrorMessage = \case
     OAuth2ResultError{} -> "Login failed, please try again"
     FetchCredsIOException{} -> "Login failed, please try again"
     FetchCredsYesodOAuth2Exception{} -> "Login failed, please try again"
+    OtherDispatchError{} -> "Login failed, please try again"
 
 handleDispatchError
     :: MonadAuthHandler site m

--- a/yesod-auth-oauth2.cabal
+++ b/yesod-auth-oauth2.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 24b7f34906d427e1cdd3a015f9b67c7d1e69b9ecab88ab0ad8e8cba65777a003
+-- hash: 11915a2e835dfb554a1ddca65479329c5ca6358094659e94899dcdacb8d5295b
 
 name:           yesod-auth-oauth2
 version:        0.6.2.3
@@ -35,6 +35,7 @@ flag example
 
 library
   exposed-modules:
+      UnliftIO.Except
       URI.ByteString.Extension
       Yesod.Auth.OAuth2
       Yesod.Auth.OAuth2.AzureAD
@@ -42,6 +43,7 @@ library
       Yesod.Auth.OAuth2.Bitbucket
       Yesod.Auth.OAuth2.ClassLink
       Yesod.Auth.OAuth2.Dispatch
+      Yesod.Auth.OAuth2.DispatchError
       Yesod.Auth.OAuth2.ErrorResponse
       Yesod.Auth.OAuth2.EveOnline
       Yesod.Auth.OAuth2.Exception
@@ -50,6 +52,7 @@ library
       Yesod.Auth.OAuth2.Google
       Yesod.Auth.OAuth2.Nylas
       Yesod.Auth.OAuth2.Prelude
+      Yesod.Auth.OAuth2.Random
       Yesod.Auth.OAuth2.Salesforce
       Yesod.Auth.OAuth2.Slack
       Yesod.Auth.OAuth2.Spotify
@@ -72,8 +75,10 @@ library
     , http-types >=0.8 && <0.13
     , memory
     , microlens
+    , mtl
     , safe-exceptions
     , text >=0.7 && <2.0
+    , unliftio
     , uri-bytestring
     , yesod-auth >=1.6.0 && <1.7
     , yesod-core >=1.6.0 && <1.7


### PR DESCRIPTION
For pass through logging.

I'd also like to enable our release github action. Will the pattern we use in bcp suffice (since this has multiple exes)?