### PR TITLE
Update .Compat for hoauth2-2.9.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         stack-yaml:
-          - stack-nightly.yaml     # ghc-9.6 + hoauth2-2.8.1
+          - stack-nightly.yaml     # ghc-9.6 + hoauth2-2.9.0
           - stack.yaml             # ghc-9.4
           - stack-lts-20.26.yaml   # ghc-9.2
           - stack-lts-19.33.yaml   # ghc-9.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## [_Unreleased_](https://github.com/thoughtbot/yesod-auth-oauth2/compare/v0.7.1.1...main)
+## [_Unreleased_](https://github.com/thoughtbot/yesod-auth-oauth2/compare/v0.7.1.2...main)
+
+## [v0.7.1.2](https://github.com/thoughtbot/yesod-auth-oauth2/compare/v0.7.1.1...v0.7.1.2)
+
+- Support `hoauth2-2.9`.
 
 ## [v0.7.1.1](https://github.com/thoughtbot/yesod-auth-oauth2/compare/v0.7.1.0...v0.7.1.1)
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,6 +1,6 @@
 ---
 name: yesod-auth-oauth2
-version: 0.7.1.1
+version: 0.7.1.2
 synopsis: OAuth 2.0 authentication plugins
 description: Library to authenticate with OAuth 2.0 for Yesod web applications.
 category: Web

--- a/src/Network/OAuth/OAuth2/Compat.hs
+++ b/src/Network/OAuth/OAuth2/Compat.hs
@@ -16,27 +16,33 @@ module Network.OAuth.OAuth2.Compat
 import Data.ByteString.Lazy (ByteString)
 import Data.Text (Text)
 import Network.HTTP.Conduit (Manager)
+import Network.OAuth.OAuth2
+  ( AccessToken (..)
+  , ExchangeToken (..)
+  , OAuth2Token (..)
+  , RefreshToken (..)
+  )
 import qualified Network.OAuth.OAuth2 as OAuth2
-#if MIN_VERSION_hoauth2(2,7,0)
-import Network.OAuth.OAuth2
-    (AccessToken(..), ExchangeToken(..), OAuth2Token(..), RefreshToken(..))
-import Network.OAuth.OAuth2.TokenRequest (TokenRequestError)
-#else
-import Network.OAuth.OAuth2
-    ( AccessToken(..)
-    , ExchangeToken(..)
-    , OAuth2Error
-    , OAuth2Token(..)
-    , RefreshToken(..)
-    )
-import qualified Network.OAuth.OAuth2.TokenRequest as LegacyTokenRequest
-#endif
 import URI.ByteString
 
 #if MIN_VERSION_hoauth2(2,2,0)
 import Control.Monad.Trans.Except (ExceptT, runExceptT)
 import Data.Maybe (fromMaybe)
 #endif
+
+#if MIN_VERSION_hoauth2(2,9,0)
+import Network.OAuth.OAuth2.TokenRequest (TokenResponseError)
+type Errors = TokenResponseError
+#elif MIN_VERSION_hoauth2(2,7,0)
+import Network.OAuth.OAuth2.TokenRequest (TokenRequestError)
+type Errors = TokenRequestError
+#else
+import qualified Network.OAuth.OAuth2.TokenRequest as LegacyTokenRequest
+import Network.OAuth.OAuth2 (OAuth2Error)
+type Errors = OAuth2Error LegacyTokenRequest.Errors
+#endif
+
+{-# ANN module ("HLint: ignore Use fewer imports" :: String) #-}
 
 data OAuth2 = OAuth2
   { oauth2ClientId :: Text
@@ -45,12 +51,6 @@ data OAuth2 = OAuth2
   , oauth2TokenEndpoint :: URIRef Absolute
   , oauth2RedirectUri :: Maybe (URIRef Absolute)
   }
-
-#if MIN_VERSION_hoauth2(2,7,0)
-type Errors = TokenRequestError
-#else
-type Errors = OAuth2Error LegacyTokenRequest.Errors
-#endif
 
 type OAuth2Result err a = Either err a
 

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -1,1 +1,3 @@
-resolver: nightly-2023-08-01
+resolver: nightly-2023-10-30
+extra-deps:
+  - hoauth2-2.9.0

--- a/stack-nightly.yaml.lock
+++ b/stack-nightly.yaml.lock
@@ -3,10 +3,17 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages: []
+packages:
+- completed:
+    hackage: hoauth2-2.9.0@sha256:b12385374771dd2d134cb88234aa80c4ab381ff0c491870a3be5f2676c3fade6,3529
+    pantry-tree:
+      sha256: 33a8b924018c8c2d7b08dfbd16ec00e6f645ab9d5c653a0e335132936641bc82
+      size: 2129
+  original:
+    hackage: hoauth2-2.9.0
 snapshots:
 - completed:
-    sha256: 05d50b875e9273b40eef9f5f7da82ec1c7728c31d99eada5bf79407399108686
-    size: 598883
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2023/8/1.yaml
-  original: nightly-2023-08-01
+    sha256: e1e4b585723b266822e37cf602d87b57c7c8774b7e5f6b84fdcc580ea5eb2bf1
+    size: 697668
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2023/10/30.yaml
+  original: nightly-2023-10-30

--- a/yesod-auth-oauth2.cabal
+++ b/yesod-auth-oauth2.cabal
@@ -1,13 +1,13 @@
 cabal-version: 1.18
 
--- This file has been generated from package.yaml by hpack version 0.35.2.
+-- This file has been generated from package.yaml by hpack version 0.36.0.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: d5fd59ca1ff45493cd002c9d0e40221e4e48694f9b3749e7a40a57a5e5513193
+-- hash: d17748cda71a5090b2883f761cea3167a59252819da563075e3983a1a248d667
 
 name:           yesod-auth-oauth2
-version:        0.7.1.1
+version:        0.7.1.2
 synopsis:       OAuth 2.0 authentication plugins
 description:    Library to authenticate with OAuth 2.0 for Yesod web applications.
 category:       Web


### PR DESCRIPTION
The only breaking change seems to be the error type, which we were
already wrapping in `CPP` and our own `Errors` synonym for 2.7. All this
change does is add a 2.9 case and move some thing around so it's
syntactically nicer.