### PR TITLE
Add support for Relative Approots non intrusive

### DIFF
--- a/src/Yesod/Auth/OAuth2/Dispatch.hs
+++ b/src/Yesod/Auth/OAuth2/Dispatch.hs
@@ -12,8 +12,8 @@ module Yesod.Auth.OAuth2.Dispatch
   , dispatchAuthRequest
   ) where
 
-import Control.Monad (unless)
 import Control.Applicative ((<|>))
+import Control.Monad (unless)
 import Control.Monad.Except (MonadError (..))
 import Data.Text (Text)
 import qualified Data.Text as T

--- a/src/Yesod/Auth/OAuth2/Dispatch.hs
+++ b/src/Yesod/Auth/OAuth2/Dispatch.hs
@@ -105,7 +105,7 @@ withCallbackAndState
   -> Text
   -> m OAuth2
 withCallbackAndState name oauth2 csrf = do
-  callback <- maybe uriFromPlugin pure $ oauth2RedirectUri oauth2
+  callback <- maybe defaultCallback pure $ oauth2RedirectUri oauth2
   pure
     oauth2
       { oauth2RedirectUri = Just callback
@@ -113,7 +113,7 @@ withCallbackAndState name oauth2 csrf = do
           oauth2AuthorizeEndpoint oauth2 `withQuery` [("state", encodeUtf8 csrf)]
       }
   where
-    uriFromPlugin = do
+    defaultCallback = do
       uri <- ($ PluginR name ["callback"]) <$> getParentUrlRender
       maybe (throwError $ InvalidCallbackUri uri) pure $ fromText uri
 

--- a/src/Yesod/Auth/OAuth2/Dispatch.hs
+++ b/src/Yesod/Auth/OAuth2/Dispatch.hs
@@ -112,10 +112,10 @@ withCallbackAndState name oauth2 csrf = do
       , oauth2AuthorizeEndpoint =
           oauth2AuthorizeEndpoint oauth2 `withQuery` [("state", encodeUtf8 csrf)]
       }
-  where
-    defaultCallback = do
-      uri <- ($ PluginR name ["callback"]) <$> getParentUrlRender
-      maybe (throwError $ InvalidCallbackUri uri) pure $ fromText uri
+ where
+  defaultCallback = do
+    uri <- ($ PluginR name ["callback"]) <$> getParentUrlRender
+    maybe (throwError $ InvalidCallbackUri uri) pure $ fromText uri
 
 getParentUrlRender :: MonadHandler m => m (Route (SubHandlerSite m) -> Text)
 getParentUrlRender = (.) <$> getUrlRender <*> getRouteToParent

--- a/src/Yesod/Auth/OAuth2/Dispatch.hs
+++ b/src/Yesod/Auth/OAuth2/Dispatch.hs
@@ -13,6 +13,7 @@ module Yesod.Auth.OAuth2.Dispatch
   ) where
 
 import Control.Monad (unless)
+import Control.Applicative ((<|>))
 import Control.Monad.Except (MonadError (..))
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -109,7 +110,7 @@ withCallbackAndState name oauth2 csrf = do
   callback <- maybe (throwError $ InvalidCallbackUri uri) pure $ fromText uri
   pure
     oauth2
-      { oauth2RedirectUri = Just callback
+      { oauth2RedirectUri = (oauth2RedirectUri oauth2) <|> Just callback
       , oauth2AuthorizeEndpoint =
           oauth2AuthorizeEndpoint oauth2 `withQuery` [("state", encodeUtf8 csrf)]
       }


### PR DESCRIPTION
By using an alternative with oauth2RedirectUri users of the library can set up their own redirect URIs.