### PR TITLE
add custom scope and/or widget options to GitHub plugin

### DIFF
--- a/src/Yesod/Auth/OAuth2/GitHub.hs
+++ b/src/Yesod/Auth/OAuth2/GitHub.hs
@@ -14,9 +14,9 @@ module Yesod.Auth.OAuth2.GitHub
   , oauth2GitHubScopedWidget
   ) where
 
+import qualified Data.Text as T
 import Yesod.Auth.OAuth2.Prelude
 import Yesod.Core (WidgetFor, whamlet)
-import qualified Data.Text as T
 
 newtype User = User Int
 
@@ -32,7 +32,8 @@ defaultScopes = ["user:email"]
 oauth2GitHub :: YesodAuth m => Text -> Text -> AuthPlugin m
 oauth2GitHub = oauth2GitHubScoped defaultScopes
 
-oauth2GitHubWidget :: YesodAuth m => WidgetFor m () -> Text -> Text -> AuthPlugin m
+oauth2GitHubWidget
+  :: YesodAuth m => WidgetFor m () -> Text -> Text -> AuthPlugin m
 oauth2GitHubWidget widget = oauth2GitHubScopedWidget widget defaultScopes
 
 oauth2GitHubScoped :: YesodAuth m => [Text] -> Text -> Text -> AuthPlugin m
@@ -40,7 +41,7 @@ oauth2GitHubScoped =
   oauth2GitHubScopedWidget [whamlet|Login via #{pluginName}|]
 
 oauth2GitHubScopedWidget
- :: YesodAuth m => WidgetFor m () ->[Text] -> Text -> Text -> AuthPlugin m
+  :: YesodAuth m => WidgetFor m () -> [Text] -> Text -> Text -> AuthPlugin m
 oauth2GitHubScopedWidget widget scopes clientId clientSecret =
   authOAuth2Widget widget pluginName oauth2 $ \manager token -> do
     (User userId, userResponse) <-

--- a/src/Yesod/Auth/OAuth2/GitHub.hs
+++ b/src/Yesod/Auth/OAuth2/GitHub.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
 
 -- |
 --
@@ -8,11 +9,13 @@
 -- * Uses github user id as credentials identifier
 module Yesod.Auth.OAuth2.GitHub
   ( oauth2GitHub
+  , oauth2GitHubWidget
   , oauth2GitHubScoped
+  , oauth2GitHubScopedWidget
   ) where
 
 import Yesod.Auth.OAuth2.Prelude
-
+import Yesod.Core (WidgetFor, whamlet)
 import qualified Data.Text as T
 
 newtype User = User Int
@@ -29,9 +32,17 @@ defaultScopes = ["user:email"]
 oauth2GitHub :: YesodAuth m => Text -> Text -> AuthPlugin m
 oauth2GitHub = oauth2GitHubScoped defaultScopes
 
+oauth2GitHubWidget :: YesodAuth m => WidgetFor m () -> Text -> Text -> AuthPlugin m
+oauth2GitHubWidget widget = oauth2GitHubScopedWidget widget defaultScopes
+
 oauth2GitHubScoped :: YesodAuth m => [Text] -> Text -> Text -> AuthPlugin m
-oauth2GitHubScoped scopes clientId clientSecret =
-  authOAuth2 pluginName oauth2 $ \manager token -> do
+oauth2GitHubScoped =
+  oauth2GitHubScopedWidget [whamlet|Login via #{pluginName}|]
+
+oauth2GitHubScopedWidget
+ :: YesodAuth m => WidgetFor m () ->[Text] -> Text -> Text -> AuthPlugin m
+oauth2GitHubScopedWidget widget scopes clientId clientSecret =
+  authOAuth2Widget widget pluginName oauth2 $ \manager token -> do
     (User userId, userResponse) <-
       authGetProfile
         pluginName


### PR DESCRIPTION
Adds functions to add custom scope and/or a custom widget to GitHub OAuth2 plugin. I followed the code in the Google OAuth2 Plugin. Tested manually with real credentials.