### PR TITLE
Bring LTS configurations up to date

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,17 +31,17 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: freckle/stack-action@v4
+      - uses: actions/checkout@v4
+      - uses: freckle/stack-action@v5
         with:
           stack-yaml: ${{ matrix.stack-yaml }}
-          stack-arguments: --flag yesod-auth-oauth2:example
+          stack-build-arguments: --flag yesod-auth-oauth2:example
 
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: haskell/actions/hlint-setup@v2
-      - uses: haskell/actions/hlint-run@v2
+      - uses: actions/checkout@v4
+      - uses: haskell-actions/hlint-setup@v2
+      - uses: haskell-actions/hlint-run@v2
         with:
           fail-on: warning

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,9 @@ jobs:
     strategy:
       matrix:
         stack-yaml:
-          - stack-nightly.yaml     # ghc-9.6 + hoauth2-2.9.0
-          - stack.yaml             # ghc-9.4
+          - stack-nightly.yaml     # ghc-9.8
+          - stack.yaml             # ghc-9.6
+          - stack-lts-21.25.yaml   # ghc-9.4
           - stack-lts-20.26.yaml   # ghc-9.2
           - stack-lts-19.33.yaml   # ghc-9.0
           - stack-lts-18.28.yaml   # ghc-8.10

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,9 @@ jobs:
         uses: freckle/haskell-tag-action@v1
 
       - if: steps.tag.outputs.tag
-        uses: freckle/stack-upload-action@main
-        with:
-          pvp-bounds: lower
+        run: stack upload --pvp-bounds lower
         env:
-          HACKAGE_API_KEY: ${{ secrets.HACKAGE_UPLOAD_API_KEY }}
+          HACKAGE_KEY: ${{ secrets.HACKAGE_UPLOAD_API_KEY }}
+
+          # Use minimum LTS to set lowest lower bounds
+          STACK_YAML: stack-lts-14.27.yaml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,12 +8,10 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - id: tag
-        uses: freckle/haskell-tag-action@main
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: freckle/haskell-tag-action@v1
 
       - if: steps.tag.outputs.tag
         uses: freckle/stack-upload-action@main

--- a/stack-lts-21.25.yaml
+++ b/stack-lts-21.25.yaml
@@ -1,0 +1,1 @@
+resolver: lts-21.25

--- a/stack-lts-21.25.yaml.lock
+++ b/stack-lts-21.25.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    sha256: e2c529ccfb21501f98f639e056cbde50470b86256d9849d7a82d414ca23e4276
-    size: 712898
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/22/12.yaml
-  original: lts-22.12
+    sha256: a81fb3877c4f9031e1325eb3935122e608d80715dc16b586eb11ddbff8671ecd
+    size: 640086
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/21/25.yaml
+  original: lts-21.25

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -1,10 +1,11 @@
-resolver: nightly-2024-02-20
+resolver: nightly-2024-02-27
 extra-deps:
   - yesod-auth-1.6.11.2
 
   # For yesod-auth
   - email-validate-2.3.2.19
   - yesod-form-1.7.6
+  - yesod-1.6.2.1
 
 allow-newer: true
 allow-newer-deps:

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -1,3 +1,11 @@
-resolver: nightly-2023-10-30
+resolver: nightly-2024-02-20
 extra-deps:
-  - hoauth2-2.9.0
+  - yesod-auth-1.6.11.2
+
+  # For yesod-auth
+  - email-validate-2.3.2.19
+  - yesod-form-1.7.6
+
+allow-newer: true
+allow-newer-deps:
+  - email-validate

--- a/stack-nightly.yaml.lock
+++ b/stack-nightly.yaml.lock
@@ -5,15 +5,29 @@
 
 packages:
 - completed:
-    hackage: hoauth2-2.9.0@sha256:b12385374771dd2d134cb88234aa80c4ab381ff0c491870a3be5f2676c3fade6,3529
+    hackage: yesod-auth-1.6.11.2@sha256:c580afaccc311ad90fc8a90210b5cf998d95350ddffb622e45282d9b640cf519,3108
     pantry-tree:
-      sha256: 33a8b924018c8c2d7b08dfbd16ec00e6f645ab9d5c653a0e335132936641bc82
-      size: 2129
+      sha256: 58e36ca675fc01109915342d4df9cb2680fd37ff20919d84694cdd1d52eb7dc3
+      size: 1013
   original:
-    hackage: hoauth2-2.9.0
+    hackage: yesod-auth-1.6.11.2
+- completed:
+    hackage: email-validate-2.3.2.19@sha256:206a835fe99a79f2360c576e3594d8add82d2f1e001d58b49a60f60233da2bf5,1380
+    pantry-tree:
+      sha256: 391475ca7c84d59b1d8de362856acd2f56321d29d54ffcd05ed2a170d4e62692
+      size: 419
+  original:
+    hackage: email-validate-2.3.2.19
+- completed:
+    hackage: yesod-form-1.7.6@sha256:42219f2c4feaa2de32280c0b8f98db818f993152693a79960808fd3001a4c0e2,3434
+    pantry-tree:
+      sha256: 8a48fc861796a61cf6abd2087fedd86844ba5c3e11c89c74d2d04c4656d69997
+      size: 1797
+  original:
+    hackage: yesod-form-1.7.6
 snapshots:
 - completed:
-    sha256: e1e4b585723b266822e37cf602d87b57c7c8774b7e5f6b84fdcc580ea5eb2bf1
-    size: 697668
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2023/10/30.yaml
-  original: nightly-2023-10-30
+    sha256: d544407168c7fd816474f52599144e791e6b0ab3a43c4168b4bbb29287f45001
+    size: 604200
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2024/2/20.yaml
+  original: nightly-2024-02-20

--- a/stack-nightly.yaml.lock
+++ b/stack-nightly.yaml.lock
@@ -25,9 +25,16 @@ packages:
       size: 1797
   original:
     hackage: yesod-form-1.7.6
+- completed:
+    hackage: yesod-1.6.2.1@sha256:504bc888257dae9bb40f4cd1e1110c4e80dfe7b867e8e207b22c4ca4dbd87f9a,2030
+    pantry-tree:
+      sha256: 5a78fa0c6e7dcb46c9acd687ab9409c8fcda0d59b930e2a93e5dc44128c740ec
+      size: 618
+  original:
+    hackage: yesod-1.6.2.1
 snapshots:
 - completed:
-    sha256: d544407168c7fd816474f52599144e791e6b0ab3a43c4168b4bbb29287f45001
-    size: 604200
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2024/2/20.yaml
-  original: nightly-2024-02-20
+    sha256: e596f5467d31095fd7b9f750e82aeffe012e38e795c13e1cdc945c9cab928085
+    size: 604415
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2024/2/27.yaml
+  original: nightly-2024-02-27

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-21.5
+resolver: lts-22.12


### PR DESCRIPTION
### [Bring LTS configurations up to date](https://github.com/freckle/yesod-auth-oauth2/pull/182/commits/8f9be059a227274445752adf394d886f1e5bc1b3)
[8f9be05](https://github.com/freckle/yesod-auth-oauth2/pull/182/commits/8f9be059a227274445752adf394d886f1e5bc1b3)

### [Rev GitHub Actions](https://github.com/freckle/yesod-auth-oauth2/pull/182/commits/bee4cd7d9b6c070d97a2c008b7224eb94b431098)
[bee4cd7](https://github.com/freckle/yesod-auth-oauth2/pull/182/commits/bee4cd7d9b6c070d97a2c008b7224eb94b431098)

### [Move away from stack-upload-action](https://github.com/freckle/yesod-auth-oauth2/pull/182/commits/a9281fa94ad04ef9bf8f69a54a5ad982241dfb8c)
[a9281fa](https://github.com/freckle/yesod-auth-oauth2/pull/182/commits/a9281fa94ad04ef9bf8f69a54a5ad982241dfb8c)

With new Stack versions (now installed on GHA runners), our action is
not required. Using `stack upload` as-is works fine.